### PR TITLE
branding: remove NAME variable

### DIFF
--- a/calamares/branding/blackarch/branding.desc
+++ b/calamares/branding/blackarch/branding.desc
@@ -121,7 +121,7 @@ navigation: widget
 # are visible as buttons there if the corresponding *show* keys
 # are set to "true" (they can also be overridden).
 strings:
-    productName:         "@{NAME}"
+    productName:         BlackArch Linux
     shortProductName:    BlackArch Linux
     version:             3.0
     shortVersion:        3.0


### PR DESCRIPTION
The variable is not evaluated and it just keeps @NAME as the actual name.