### PR TITLE
unpackfs: remove initramfs

### DIFF
--- a/calamares/modules/unpackfs.conf
+++ b/calamares/modules/unpackfs.conf
@@ -11,11 +11,6 @@ unpack:
       exclude: ["/etc/sudoers.d/*"]
       weight: 160
 
-    - source: "/run/archiso/bootmnt/blackarch/x86_64/initramfs-linux.img"
-      source: file
-      destination: "/boot"
-      weight: 5
-
     - source: "/run/archiso/bootmnt/blackarch/boot/x86_64/vmlinuz-linux"
       sourcefs: file
       destination: "/boot"


### PR DESCRIPTION
It's causing a KeyError exception, when removed the install process works